### PR TITLE
Add config reload API

### DIFF
--- a/authenticator.go
+++ b/authenticator.go
@@ -75,18 +75,17 @@ func (a *ReplaceableAuthenticator) Close() error {
 	return a.Engine.Close()
 }
 
-// InitializeAuthenticator initializes an authenticator wrapped with ReplaceableAuthenticator.
+// InitializeAuthenticator initializes a Redis or Memory authenticator.
 func InitializeAuthenticator(config *Config) Authenticator {
 	// If Redis, create a Redis connection.
 	if config.Redis.Enabled {
-		return &ReplaceableAuthenticator{Engine: InitializeRedisAuthenticator(config)}
+		return InitializeRedisAuthenticator(config)
 	}
 	// Create the authenticator.
-	authenticator := &MemoryAuthenticator{
+	return &MemoryAuthenticator{
 		Config: config,
 		Tokens: make(map[string]string),
 	}
-	return &ReplaceableAuthenticator{Engine: authenticator}
 }
 
 // InitializeRedisAuthenticator initializes an authenticator using Redis.

--- a/connector.go
+++ b/connector.go
@@ -101,6 +101,7 @@ func InitializeConnector(config *Config) *Connector {
 		GET /login
 		GET /logout
 		GET /ott (one-time ticket)
+
 		GET /config/reload
 
 		GET /servers
@@ -235,8 +236,9 @@ func (connector *Connector) registerRoutes() {
 		replaceableAuthenticator := connector.Authenticator.(*ReplaceableAuthenticator)
 		replaceableAuthenticator.EngineMutex.Lock()
 		defer replaceableAuthenticator.EngineMutex.Unlock()
-		redisAuth, usingRedis := replaceableAuthenticator.Engine.(*RedisAuthenticator)
-		if usingRedis != config.Redis.Enabled || (usingRedis && redisAuth.Config.Redis.URL != config.Redis.URL) {
+		redisAuthenticator, usingRedis := replaceableAuthenticator.Engine.(*RedisAuthenticator)
+		if usingRedis != config.Redis.Enabled ||
+			(usingRedis && redisAuthenticator.Config.Redis.URL != config.Redis.URL) {
 			replaceableAuthenticator.Engine.Close() // Bypassing ReplaceableAuthenticator mutex Lock.
 			replaceableAuthenticator.Engine = InitializeAuthenticator(&config)
 		}
@@ -266,6 +268,7 @@ func (connector *Connector) registerRoutes() {
 			}
 			return true
 		})
+		// TODO: Reload HTTP server, mark server for deletion instead of instantly deleting them.
 		// Send the response.
 		fmt.Fprint(w, "{\"success\":true}")
 	})

--- a/file_connector.go
+++ b/file_connector.go
@@ -45,6 +45,8 @@ func (connector *Connector) registerFileRoutes() {
 			return
 		}
 		// Check if folder is in the process directory or not.
+		process.ServerConfigMutex.RLock()
+		defer process.ServerConfigMutex.RUnlock()
 		folderPath := joinPath(process.Directory, r.URL.Query().Get("path"))
 		if !strings.HasPrefix(folderPath, path.Clean(process.Directory)) {
 			http.Error(w, "{\"error\":\"The folder requested is outside the server!\"}", http.StatusForbidden)
@@ -115,6 +117,8 @@ func (connector *Connector) registerFileRoutes() {
 			return
 		}
 		// Check if path is in the process directory or not.
+		process.ServerConfigMutex.RLock()
+		defer process.ServerConfigMutex.RUnlock()
 		filePath := joinPath(process.Directory, r.URL.Query().Get("path"))
 		if (r.Method == "GET" || r.Method == "POST" || r.Method == "DELETE") &&
 			!strings.HasPrefix(filePath, path.Clean(process.Directory)) {
@@ -281,6 +285,8 @@ func (connector *Connector) registerFileRoutes() {
 		}
 		if r.Method == "POST" {
 			// Check if the folder already exists.
+			process.ServerConfigMutex.RLock()
+			defer process.ServerConfigMutex.RUnlock()
 			file := joinPath(process.Directory, r.URL.Query().Get("path"))
 			// Check if folder is in the process directory or not.
 			if !strings.HasPrefix(file, path.Clean(process.Directory)) {
@@ -335,6 +341,8 @@ func (connector *Connector) registerFileRoutes() {
 				return
 			}
 			// Validate every path.
+			process.ServerConfigMutex.RLock()
+			defer process.ServerConfigMutex.RUnlock()
 			for _, file := range files {
 				filepath := joinPath(process.Directory, file)
 				if !strings.HasPrefix(filepath, path.Clean(process.Directory)) {
@@ -401,6 +409,8 @@ func (connector *Connector) registerFileRoutes() {
 			http.Error(w, "{\"error\":\"This server does not exist!\"}", http.StatusNotFound)
 			return
 		}
+		process.ServerConfigMutex.RLock()
+		defer process.ServerConfigMutex.RUnlock()
 		directory := path.Clean(process.Directory)
 		if r.Method == "POST" {
 			// Check if the ZIP file exists.

--- a/process.go
+++ b/process.go
@@ -9,11 +9,13 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
 // Process defines a process running in octyne.
 type Process struct {
+	ServerConfigMutex sync.RWMutex
 	ServerConfig
 	Name    string
 	Command *exec.Cmd
@@ -50,6 +52,8 @@ func CreateProcess(name string, config ServerConfig, connector *Connector) *Proc
 func (process *Process) StartProcess() error {
 	name := process.Name
 	info.Println("Starting process (" + name + ")")
+	process.ServerConfigMutex.RLock()
+	defer process.ServerConfigMutex.RUnlock()
 	// Determine the command which should be run by Go and change the working directory.
 	cmd := strings.Split(process.ServerConfig.Command, " ")
 	command := exec.Command(cmd[0], cmd[1:]...)


### PR DESCRIPTION
Partially fixes #1

Test:
- [x] Creating new servers.
- [x] Modifying existing servers.
- [x] Deleting existing servers.
- [x] Changing authenticator config for Redis.

This API currently does not support HTTP server configuration reload.