### PR TITLE
Implement Unix socket API for local actions

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,5 +1,13 @@
 # Octyne API Documentation
 
+Octyne provides a REST API for interacting with the server (listening on port 42069 by default, but configurable). This API is used by the [Ecthelion web interface](https://github.com/retrixe/ecthelion) and can be used by other applications to interact with Octyne.
+
+## Unix Socket API
+
+Octyne provides a Unix socket API on Windows 10+ and Unix-like systems which is located by default at `TEMPDIR/octyne.sock.PORT`, where `TEMPDIR` is retrieved from <https://pkg.go.dev/os#TempDir> and `PORT` is the port specified in the config (the default is 42069). If using an older version of Windows, the Unix socket API will be unavailable.
+
+This API is identical to the REST API in usage, with the same endpoints/params/etc. You can send HTTP requests to this API without requiring token authentication, only necessary system user/group privileges, which is useful for local actions performed by applications like [octynectl](https://github.com/retrixe/octynectl). Actions performed through the Unix socket API are logged as being performed by the `@local` user.
+
 ## Authentication
 
 Retrieve a token using the [GET /login](#get-login) endpoint and store it safely. You can then pass this token to all subsequent requests to Octyne in the `Authorization` header or as an `X-Authentication` cookie.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Used to configure the apps Octyne should start, Redis-based authentication for a
 ```json
 {
   "port": 42069, // optional, default is 42069
+  "uds": {
+    "enabled": true, // enables Unix socket API for auth-less local actions, used by octynectl
+    "location": "" // optional, default is /tmp/octyne.sock.PORT, specifying this overrides defaults
+  },
   "redis": {
     "enabled": false, // whether the authentication tokens should sync to Redis for more than 1 node
     "url": "redis://localhost" // link to Redis server

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Used to configure the apps Octyne should start, Redis-based authentication for a
 ```json
 {
   "port": 42069, // optional, default is 42069
-  "uds": {
+  "unixSocket": {
     "enabled": true, // enables Unix socket API for auth-less local actions, used by octynectl
     "location": "" // optional, default is /tmp/octyne.sock.PORT, specifying this overrides defaults
   },

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A process manager with an HTTP API for remote console and file access.
 
-Octyne allows running multiple apps on a remote server and providing an HTTP API to manage them. This allows for hosting web servers, game servers, bots and so on on remote servers without having to mess with SSH, using `screen` and `systemd` whenever you want to make any change, in a highly manageable and secure way.
+Octyne allows running multiple apps on a remote server and provides an HTTP API to manage them. This allows for hosting web servers, game servers, bots and so on on remote servers without having to mess with SSH, using `screen` and `systemd` whenever you want to make any change, in a highly manageable and secure way.
 
 It incorporates the ability to manage files and access the terminal output and input over HTTP remotely. For further security, it is recommended to use HTTPS (see [config.json](#configjson)) to ensure end-to-end secure transmission.
 
@@ -14,7 +14,7 @@ It incorporates the ability to manage files and access the terminal output and i
 - Place octyne in a folder, and run `chmod +x <octyne file name>` to mark it as executable if using macOS/Linux/*nix-like.
 - Follow the steps [here](https://github.com/retrixe/octyne#configuration) to configure Octyne correctly.
 - Run `./<octyne file name>` (`.\<octyne file name>.exe` on Windows) in a terminal in the folder to start Octyne. Alternatively, on Windows/Linux desktops, you can double click the file (on Linux, select `Run in Terminal`, else it will run in the background).
-- You may want to get [Ecthelion](https://github.com/retrixe/ecthelion) as aforementioned in the description, as a web app to manage Octyne.
+- You may want to get [Ecthelion](https://github.com/retrixe/ecthelion) as aforementioned in the description, as a web app to manage Octyne, and [octynectl](https://github.com/retrixe/octynectl) as a CLI tool to manage Octyne locally on your machine.
 
 ### Usage
 
@@ -28,7 +28,7 @@ Octyne depends on two files in the same directory to get configuration from. Not
 
 ### config.json
 
-Used to configure the apps Octyne should start, Redis-based authentication for allowing more than a single node and HTTPS support. A reverse proxy can also be used for HTTPS if it supports WSS.
+Used to configure the apps Octyne should start, Redis-based authentication for allowing more than a single node, Unix socket API, and HTTPS support. A reverse proxy can also be used for HTTPS if it supports WSS.
 
 *NOTE: Remove the comments when creating the file as JSON does not support comments!*
 
@@ -36,8 +36,8 @@ Used to configure the apps Octyne should start, Redis-based authentication for a
 {
   "port": 42069, // optional, default is 42069
   "unixSocket": {
-    "enabled": true, // enables Unix socket API for auth-less local actions, used by octynectl
-    "location": "" // optional, default is /tmp/octyne.sock.PORT, specifying this overrides defaults
+    "enabled": true, // enables Unix socket API for auth-less actions by locally running apps e.g. octynectl
+    "location": "" // optional, if empty/absent, default is TMP/octyne.sock.PORT (see API.md for details)
   },
   "redis": {
     "enabled": false, // whether the authentication tokens should sync to Redis for more than 1 node
@@ -72,6 +72,8 @@ Contains users who can log into Octyne. Use a secure method to hash your passwor
   "username": "password hashed with SHA-256"
 }
 ```
+
+Note: actions performed locally using the Unix socket API by apps like [octynectl](https://github.com/retrixe/octynectl) are logged as being performed by the `@local` user, avoid using this username. Apps running on your PC under the same user as Octyne can use this API without a username or password.
 
 ### Logging
 

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -33,6 +33,10 @@ type ReplaceableAuthenticator struct {
 
 // Validate is called on an HTTP API request and checks whether or not the user is authenticated.
 func (a *ReplaceableAuthenticator) Validate(w http.ResponseWriter, r *http.Request) string {
+	if r.RemoteAddr == "@" { // TODO: I'm not sure this is great? Should we have a better username?
+		return "unix:local"
+	}
+
 	a.EngineMutex.RLock()
 	defer a.EngineMutex.RUnlock()
 	return a.Engine.Validate(w, r)

--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -33,8 +33,8 @@ type ReplaceableAuthenticator struct {
 
 // Validate is called on an HTTP API request and checks whether or not the user is authenticated.
 func (a *ReplaceableAuthenticator) Validate(w http.ResponseWriter, r *http.Request) string {
-	if r.RemoteAddr == "@" { // TODO: I'm not sure this is great? Should we have a better username?
-		return "unix:local"
+	if r.RemoteAddr == "@" {
+		return "@local"
 	}
 
 	a.EngineMutex.RLock()

--- a/auth/memory.go
+++ b/auth/memory.go
@@ -18,6 +18,10 @@ func NewMemoryAuthenticator() Authenticator {
 
 // Validate is called on an HTTP API request and checks whether or not the user is authenticated.
 func (a *MemoryAuthenticator) Validate(w http.ResponseWriter, r *http.Request) string {
+	if r.RemoteAddr == "@" {
+		return "unix:local"
+	}
+
 	token := GetTokenFromRequest(r)
 	if !isValidToken(token) {
 		http.Error(w, "{\"error\": \"You are not authenticated to access this resource!\"}",

--- a/auth/memory.go
+++ b/auth/memory.go
@@ -19,7 +19,7 @@ func NewMemoryAuthenticator() Authenticator {
 // Validate is called on an HTTP API request and checks whether or not the user is authenticated.
 func (a *MemoryAuthenticator) Validate(w http.ResponseWriter, r *http.Request) string {
 	if r.RemoteAddr == "@" {
-		return "unix:local"
+		return "@local"
 	}
 
 	token := GetTokenFromRequest(r)

--- a/auth/redis.go
+++ b/auth/redis.go
@@ -34,6 +34,10 @@ func NewRedisAuthenticator(url string) *RedisAuthenticator {
 
 // Validate is called on an HTTP API request and checks whether or not the user is authenticated.
 func (a *RedisAuthenticator) Validate(w http.ResponseWriter, r *http.Request) string {
+	if r.RemoteAddr == "@" {
+		return "unix:local"
+	}
+
 	token := GetTokenFromRequest(r)
 	if !isValidToken(token) {
 		http.Error(w, "{\"error\": \"You are not authenticated to access this resource!\"}",

--- a/auth/redis.go
+++ b/auth/redis.go
@@ -35,7 +35,7 @@ func NewRedisAuthenticator(url string) *RedisAuthenticator {
 // Validate is called on an HTTP API request and checks whether or not the user is authenticated.
 func (a *RedisAuthenticator) Validate(w http.ResponseWriter, r *http.Request) string {
 	if r.RemoteAddr == "@" {
-		return "unix:local"
+		return "@local"
 	}
 
 	token := GetTokenFromRequest(r)

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import "encoding/json"
 // Config is the main config for Octyne.
 type Config struct {
 	Port    uint16                  `json:"port"`
+	UDS     UDSConfig               `json:"uds"`
 	HTTPS   HTTPSConfig             `json:"https"`
 	Redis   RedisConfig             `json:"redis"`
 	Logging LoggingConfig           `json:"logging"`
@@ -13,6 +14,9 @@ type Config struct {
 
 var defaultConfig = Config{
 	Port: 42069,
+	UDS: UDSConfig{
+		Enabled: true,
+	},
 	Logging: LoggingConfig{
 		Enabled: true,
 		Path:    "logs",
@@ -40,6 +44,21 @@ type HTTPSConfig struct {
 	Enabled bool   `json:"enabled"`
 	Cert    string `json:"cert"`
 	Key     string `json:"key"`
+}
+
+// UDSConfig contains whether or not UDS is enabled, and if so, path to the UDS socket.
+type UDSConfig struct {
+	Enabled  bool   `json:"enabled"`
+	Location string `json:"location"`
+}
+
+// UnmarshalJSON unmarshals UDSConfig and sets default values.
+func (c *UDSConfig) UnmarshalJSON(data []byte) error {
+	type alias UDSConfig // Prevent recursive calls to UnmarshalJSON.
+	conf := alias{Enabled: true}
+	err := json.Unmarshal(data, &conf)
+	*c = UDSConfig(conf)
+	return err
 }
 
 // ServerConfig is the config for individual servers.

--- a/config.go
+++ b/config.go
@@ -4,17 +4,17 @@ import "encoding/json"
 
 // Config is the main config for Octyne.
 type Config struct {
-	Port    uint16                  `json:"port"`
-	UDS     UDSConfig               `json:"uds"`
-	HTTPS   HTTPSConfig             `json:"https"`
-	Redis   RedisConfig             `json:"redis"`
-	Logging LoggingConfig           `json:"logging"`
-	Servers map[string]ServerConfig `json:"servers"`
+	Port       uint16                  `json:"port"`
+	UnixSocket UnixSocketConfig        `json:"unixSocket"`
+	HTTPS      HTTPSConfig             `json:"https"`
+	Redis      RedisConfig             `json:"redis"`
+	Logging    LoggingConfig           `json:"logging"`
+	Servers    map[string]ServerConfig `json:"servers"`
 }
 
 var defaultConfig = Config{
 	Port: 42069,
-	UDS: UDSConfig{
+	UnixSocket: UnixSocketConfig{
 		Enabled: true,
 	},
 	Logging: LoggingConfig{
@@ -46,18 +46,18 @@ type HTTPSConfig struct {
 	Key     string `json:"key"`
 }
 
-// UDSConfig contains whether or not UDS is enabled, and if so, path to the UDS socket.
-type UDSConfig struct {
+// UnixSocketConfig contains whether or not Unix socket is enabled, and if so, path to socket.
+type UnixSocketConfig struct {
 	Enabled  bool   `json:"enabled"`
 	Location string `json:"location"`
 }
 
-// UnmarshalJSON unmarshals UDSConfig and sets default values.
-func (c *UDSConfig) UnmarshalJSON(data []byte) error {
-	type alias UDSConfig // Prevent recursive calls to UnmarshalJSON.
+// UnmarshalJSON unmarshals UnixSocketConfig and sets default values.
+func (c *UnixSocketConfig) UnmarshalJSON(data []byte) error {
+	type alias UnixSocketConfig // Prevent recursive calls to UnmarshalJSON.
 	conf := alias{Enabled: true}
 	err := json.Unmarshal(data, &conf)
-	*c = UDSConfig(conf)
+	*c = UnixSocketConfig(conf)
 	return err
 }
 

--- a/connector.go
+++ b/connector.go
@@ -590,5 +590,5 @@ func (connector *Connector) UpdateConfig(config *Config) {
 		}
 		return true
 	})
-	// TODO: Reload HTTP server, mark server for deletion instead of instantly deleting them.
+	// TODO: Reload HTTP/Unix socket server, mark server for deletion instead of instantly deleting them.
 }


### PR DESCRIPTION
This allows taking actions without needing a username/password if you have the appropriate file read/write privileges.
All actions will show as taken by the `@local` user.

- [x] Unix socket isn't closed on shutdown...
- [x] Is `unix:local` a good name?
- [x] Test on Windows.
- [x] Finish documentation.