### PR TITLE
Add transactional file API for mv/cp/rm operations

### DIFF
--- a/system/fileutil_unix.go
+++ b/system/fileutil_unix.go
@@ -2,8 +2,47 @@
 
 package system
 
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"syscall"
+)
+
 // IsFileLocked checks if a file is locked.
 func IsFileLocked(_ error) bool {
 	// We could look for advisory locks with `lsof` but this is generally not what Unix users expect...
 	return false
+}
+
+// CanDeleteFolder checks if a folder can be deleted, checking its children recursively.
+func CanDeleteFolder(path string) (int, string) {
+	groups, err := os.Getgroups()
+	if err == nil {
+		user := os.Geteuid()
+		err = filepath.Walk(path, func(_ string, stat fs.FileInfo, err error) error {
+			if err != nil {
+				return err
+			} else if stat.IsDir() {
+				sysStat, ok := stat.Sys().(*syscall.Stat_t)
+				if !ok || !((int(sysStat.Uid) == user && stat.Mode().Perm()&0o200 != 0) ||
+					(slices.Contains(groups, int(sysStat.Gid)) && stat.Mode().Perm()&0o020 != 0) ||
+					stat.Mode().Perm()&0o002 != 0) {
+					return os.ErrPermission
+				}
+			}
+			return nil
+		})
+		if err != nil && os.IsNotExist(err) {
+			return 400, "The file specified in path does not exist!"
+		} else if err != nil && os.IsPermission(err) {
+			return 403, "Insufficient permissions to delete the file/folder!"
+		} else if err != nil {
+			return 500, "Internal Server Error! " + err.Error()
+		}
+	} else {
+		return 500, "Internal Server Error! " + err.Error()
+	}
+	return 0, ""
 }

--- a/system/fileutil_windows.go
+++ b/system/fileutil_windows.go
@@ -16,3 +16,8 @@ func IsFileLocked(err error) bool {
 	return linkErr.Err != nil && linkErr.Err.Error() ==
 		"The process cannot access the file because it is being used by another process."
 }
+
+// CanDeleteFolder checks if a folder can be deleted, checking its children recursively.
+func CanDeleteFolder(_ string) (int, string) {
+	return 0, "" // TODO: Currently Windows ACLs are not supported.
+}


### PR DESCRIPTION
Feature complete, but requires Ecthelion equivalent to be completed and tested before merging to avoid bugs

Closes #5 